### PR TITLE
fix: deprecated var usage

### DIFF
--- a/PflPlugin.php
+++ b/PflPlugin.php
@@ -223,7 +223,7 @@ class PflPlugin extends GenericPlugin {
         }
 
         if ($this->getSetting($journal->getId(), 'includeMedline')) {
-            $pflIndexList["https://www.ncbi.nlm.nih.gov/nlmcatalog/?term=${onlineIssn}[ISSN]"] = ['name' => 'M', 'description' => 'Medline'];
+            $pflIndexList["https://www.ncbi.nlm.nih.gov/nlmcatalog/?term={$onlineIssn}[ISSN]"] = ['name' => 'M', 'description' => 'Medline'];
         }
 
         if ($this->getSetting($journal->getId(), 'includeLatindex')) {


### PR DESCRIPTION
Fixes Deprecated: Using ${var} in strings is deprecated, use {$var} instead